### PR TITLE
Pin geo-types to 0.7.8.

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -368,9 +368,9 @@ dependencies = [
 
 [[package]]
 name = "geo-types"
-version = "0.7.7"
+version = "0.7.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8d77ceb80f375dc4cda113a3ae1b06a36ef623f8f035c03752ca6698f4ddfee"
+checksum = "e26879b63ac36ca5492918dc16f8c1e604b0f70f884fffbd3533f89953ab1991"
 dependencies = [
  "num-traits",
 ]


### PR DESCRIPTION
Pin `geo-types` to 0.7.8 to address georust/geo#932, which breaks the build on recent Rust versions.

(The latest version of `geo-types` is 0.7.10, but conservatively upgrading to 0.7.8 is all that is required to fix the build.)