### PR TITLE
Remove local toolchains from GitHub Actions configuration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,22 +23,6 @@ jobs:
           target: ${{ matrix.rust_target }}
           toolchain: stable
           override: true
-      - name: Install Musl
-        if: matrix.rust_target == 'x86_64-unknown-linux-musl'
-        run: sudo apt-get install musl-tools
-      - name: Install MinGW
-        if: matrix.rust_target == 'x86_64-pc-windows-gnu'
-        run: sudo apt-get install mingw-w64
-      - name: Install RiscV stuff
-        if: matrix.rust_target == 'riscv64gc-unknown-linux-gnu'
-        run: sudo apt-get install gcc-riscv64-linux-gnu
-      - name: Install ARM stuff
-        if: matrix.rust_target == 'aarch64-unknown-linux-gnu'
-        run: sudo apt-get install gcc-aarch64-linux-gnu
-      # - name: Build
-      #   run: |
-      #     cd cli
-      #     cargo build --profile ci-build --locked --target ${{ matrix.rust_target }}
 
       - name: Build
         uses: actions-rs/cargo@v1


### PR DESCRIPTION
With `cross`, cross-compiled builds are self-contained in a Docker container downloaded by `cross`; thus it is not necessary to install `musl-tools`, MinGW, various `gcc` flavors, etc. in the local environment.

Removing these installation steps from the GitHub Actions workflow simplifies the build process and marginally improves build times.