### PR TITLE
Add support for pgvector types

### DIFF
--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -968,9 +968,9 @@ dependencies = [
 
 [[package]]
 name = "parquet"
-version = "54.0.0"
+version = "54.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3334c50239d9f4951653d84fa6f636da86f53742e5e5849a30fbe852f3ff4383"
+checksum = "f88838dca3b84d41444a0341b19f347e8098a3898b0f21536654b8b799e11abd"
 dependencies = [
  "ahash",
  "base64",

--- a/cli/Cargo.lock
+++ b/cli/Cargo.lock
@@ -1015,10 +1015,12 @@ dependencies = [
  "chrono",
  "clap",
  "eui48",
+ "half",
  "jemallocator",
  "native-tls",
  "parquet",
  "pg_bigdecimal",
+ "pgvector",
  "postgres",
  "postgres-native-tls",
  "postgres-protocol",
@@ -1037,6 +1039,17 @@ dependencies = [
  "bytes",
  "num",
  "postgres",
+]
+
+[[package]]
+name = "pgvector"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e0e8871b6d7ca78348c6cd29b911b94851f3429f0cd403130ca17f26c1fb91a6"
+dependencies = [
+ "bytes",
+ "half",
+ "postgres-types",
 ]
 
 [[package]]

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -14,6 +14,8 @@ edition = "2021"
 [dependencies]
 parquet = { version = "54.0.0", default-features = false, features = ["zstd", "lz4", "flate2", "brotli", "snap", "base64"] }
 postgres = { version = "0.19.9", features = ["with-chrono-0_4", "with-serde_json-1", "with-bit-vec-0_6", "with-uuid-1", "with-geo-types-0_7", "with-eui48-1"] }
+pgvector = { version = "0.4", features = ["postgres", "halfvec"] }
+half = { version = "2.4.1" }
 clap = { version = "4.0.10", features = ["derive"] }
 uuid = "1.4.1"
 chrono = "0.4.26"

--- a/cli/Cargo.toml
+++ b/cli/Cargo.toml
@@ -12,7 +12,7 @@ edition = "2021"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-parquet = { version = "54.0.0", default-features = false, features = ["zstd", "lz4", "flate2", "brotli", "snap", "base64"] }
+parquet = { version = "54.2.1", default-features = false, features = ["zstd", "lz4", "flate2", "brotli", "snap", "base64"] }
 postgres = { version = "0.19.9", features = ["with-chrono-0_4", "with-serde_json-1", "with-bit-vec-0_6", "with-uuid-1", "with-geo-types-0_7", "with-eui48-1"] }
 pgvector = { version = "0.4", features = ["postgres", "halfvec"] }
 half = { version = "2.4.1" }

--- a/cli/src/appenders/fixed_byte_array.rs
+++ b/cli/src/appenders/fixed_byte_array.rs
@@ -1,0 +1,159 @@
+use std::{marker::PhantomData, sync::Arc, borrow::Cow};
+
+use byteorder::{ReadBytesExt, ByteOrder, BigEndian};
+use bytes::{Bytes, BufMut};
+use parquet::{data_type::{ByteArray, ByteArrayType, DataType, FixedLenByteArray, FixedLenByteArrayType}, errors::ParquetError, file::writer::SerializedColumnWriter};
+
+use crate::{appenders::byte_array, level_index::{LevelIndexList, LevelIndexState}, myfrom::MyFrom, pg_custom_types::{PgAbstractRow, PgAnyRef}};
+
+use super::{real_memory_size::RealMemorySize, ColumnAppenderBase, ColumnAppender, DynamicSerializedWriter};
+
+pub struct FixedByteArrayColumnAppender<TPg, FCopyTo: Fn(&TPg, &mut [u8]) -> Option<usize>> {
+	max_dl: i16,
+	max_rl: i16,
+	nullable: bool,
+	length: usize,
+	byte_buffer: Vec<u8>,
+	dls: Vec<i16>,
+	rls: Vec<i16>,
+	repetition_index: LevelIndexState,
+	conversion: FCopyTo,
+	_dummy: PhantomData<TPg>,
+}
+
+impl<TPg, FCopyTo: Fn(&TPg, &mut [u8]) -> Option<usize>> FixedByteArrayColumnAppender<TPg, FCopyTo> {
+	pub fn new(max_dl: i16, max_rl: i16, length: usize, nullable: bool, f_copy: FCopyTo) -> Self {
+		if max_dl < 0 || max_rl < 0 {
+			panic!("Cannot create {} with max_dl={}, max_rl={}", std::any::type_name::<Self>(), max_dl, max_rl);
+		}
+		FixedByteArrayColumnAppender {
+			max_dl, max_rl,
+			byte_buffer: Vec::new(),
+			length,
+			nullable,
+			_dummy: PhantomData,
+			dls: Vec::new(),
+			rls: Vec::new(),
+			repetition_index: LevelIndexState::new(max_rl),
+			conversion: f_copy,
+		}
+	}
+
+	pub fn append(&mut self, repetition_index: &LevelIndexList, value: &TPg) -> usize {
+		let index = self.byte_buffer.len();
+		if let Some(len) = (self.conversion)(value, &mut self.byte_buffer) {
+			debug_assert_eq!(index + len, self.byte_buffer.len());
+
+			if self.max_dl > 0 {
+				self.dls.push(self.max_dl);
+			}
+			if self.max_rl > 0 {
+				let rl = self.repetition_index.copy_and_diff(repetition_index);
+	
+				// println!("Appending {:?} with RL: {}, {:?} {:?}", self.column.last().unwrap(),  rl, self_ri, repetition_index);
+				self.rls.push(rl);
+			}
+
+			len + 2 * (self.max_dl > 0) as usize + 2 * (self.max_rl > 0) as usize
+		} else {
+			self.write_null(repetition_index, self.max_dl - 1)
+		}
+	}
+
+	pub fn append_array(&mut self, repetition_index1: &LevelIndexList, values: &[TPg]) -> usize {
+		let mut len = 0;
+		for value in values {
+			len += self.append(repetition_index1, value);
+		}
+		len
+	}
+
+	fn write_null(&mut self, repetition_index: &LevelIndexList, level: i16) -> usize {
+		debug_assert!(level < self.max_dl);
+
+		self.dls.push(level);
+		if self.max_rl > 0 {
+			let rl = self.repetition_index.copy_and_diff(repetition_index);
+			self.rls.push(rl);
+			4
+		} else {
+			2
+		}
+	}
+
+	fn write_column(&mut self, writer: &mut SerializedColumnWriter) -> Result<(), ParquetError> {
+		let dls = if self.max_dl > 0 { Some(self.dls.as_slice()) } else { None };
+		let rls = if self.max_rl > 0 { Some(self.rls.as_slice()) } else { None };
+
+		let writer_t = writer.typed::<FixedLenByteArrayType>();
+
+		if self.byte_buffer.len() == 0 {
+			assert_eq!(0, self.byte_buffer.len());
+			writer_t.write_batch(&[], dls, rls)?;
+			self.dls.clear();
+			self.rls.clear();
+			return Ok(());
+		}
+
+		let mut byte_array = Vec::new();
+		std::mem::swap(&mut self.byte_buffer, &mut byte_array);
+		let byte_array = Bytes::from(byte_array);
+
+		let mut column: Vec<FixedLenByteArray> = vec![FixedLenByteArray::default(); byte_array.len() / self.length];
+		for i in 0..column.len() {
+			let b: Bytes = byte_array.slice(i * self.length..(i + 1) * self.length);
+			column[i] = FixedLenByteArray::from(ByteArray::from(b));
+		}
+
+		let _num_written = writer_t.write_batch(&column, dls, rls)?;
+		let buffer_length = byte_array.len();
+		std::mem::drop((column, byte_array));
+		self.byte_buffer.reserve(buffer_length);
+
+		assert_eq!(0, self.byte_buffer.len());
+		self.dls.clear();
+		self.rls.clear();
+
+		Ok(())
+	}
+}
+
+impl<TPg: Clone, FCopyTo: Fn(&TPg, &mut [u8]) -> Option<usize>> ColumnAppenderBase for FixedByteArrayColumnAppender<TPg, FCopyTo> {
+
+	fn write_columns<'b>(&mut self, column_i: usize, next_col: &mut dyn DynamicSerializedWriter) -> Result<(), String> {
+		let mut error = None;
+		let c = next_col.next_column(&mut |mut column| {
+			let result = self.write_column(&mut column);
+			let error1 = result.err();
+			let result2 = column.close();
+
+			error = error1.or(result2.err());
+			
+		}).map_err(|e| format!("Could not create column[{}]: {}", column_i, e))?;
+
+		if error.is_some() {
+			return Err(format!("Couldn't write data of column[{}]: {}", column_i, error.unwrap()));
+		}
+
+		if !c {
+			return Err("Not enough columns".to_string());
+		}
+
+		Ok(())
+	}
+
+	fn write_null(&mut self, repetition_index: &LevelIndexList, level: i16) -> Result<usize, String> {
+		Ok(self.write_null(repetition_index, level))
+	}
+
+	fn max_dl(&self) -> i16 { self.max_dl }
+	fn max_rl(&self) -> i16 { self.max_rl }
+}
+
+impl<TPg: Clone, FCopyTo: Fn(&TPg, &mut [u8]) -> Option<usize>> ColumnAppender<TPg> for FixedByteArrayColumnAppender<TPg, FCopyTo> {
+	fn copy_value(&mut self, repetition_index: &LevelIndexList, value: Cow<TPg>) -> Result<usize, String> {
+		let byte_size = self.append(repetition_index, value.as_ref());
+		
+		Ok(byte_size)
+	}
+}

--- a/cli/src/appenders/generic.rs
+++ b/cli/src/appenders/generic.rs
@@ -87,8 +87,8 @@ impl<TPg, TPq, FConversion> ColumnAppenderBase for GenericColumnAppender<TPg, TP
 		}).map_err(|e| format!("Could not create column[{}]: {}", column_i, e))?;
 
 		debug_assert!(col_descriptor.is_some());
-		debug_assert_eq!(col_descriptor.as_ref().unwrap().0.max_def_level(), self.max_dl);
-		debug_assert_eq!(col_descriptor.as_ref().unwrap().0.max_rep_level(), self.max_rl);
+		debug_assert_eq!(col_descriptor.as_ref().unwrap().0.max_def_level(), self.max_dl, "unexpected max_dl={} in {}", self.max_dl, col_descriptor.as_ref().unwrap().0.path());
+		debug_assert_eq!(col_descriptor.as_ref().unwrap().0.max_rep_level(), self.max_rl, "unexpected max_rl={} in {}", self.max_rl, col_descriptor.as_ref().unwrap().0.path());
 
 		if error.is_some() {
 			let col_name = col_descriptor.map(|(desc, _, _)| desc.path().string()).unwrap_or_else(|| format!("column[{}]", column_i));

--- a/cli/src/appenders/merged.rs
+++ b/cli/src/appenders/merged.rs
@@ -59,6 +59,8 @@ pub fn new_static_merged_appender<T: Clone>(max_dl: i16, max_rl: i16) -> impl St
 pub trait StaticMergedAppender<T: Clone>: ColumnAppender<T> {
     fn add_appender<A: ColumnAppender<T>>(self, appender: A) -> StaticMergedAppenderImpl<T, A, Self>
         where Self: Sized {
+        assert_eq!(self.max_dl(), appender.max_dl());
+        assert_eq!(self.max_rl(), appender.max_rl());
         StaticMergedAppenderImpl { appender, next: self, _dummy: PhantomData }
     }
     fn add_appender_map<A: ColumnAppender<T2>, T2: Clone, F: Fn(Cow<T>) -> Cow<T2>>(self, appender: A, f: F) -> StaticMergedAppenderImpl<T, PreprocessAppender<T, T2, A, F>, Self>

--- a/cli/src/appenders/merged.rs
+++ b/cli/src/appenders/merged.rs
@@ -59,8 +59,6 @@ pub fn new_static_merged_appender<T: Clone>(max_dl: i16, max_rl: i16) -> impl St
 pub trait StaticMergedAppender<T: Clone>: ColumnAppender<T> {
     fn add_appender<A: ColumnAppender<T>>(self, appender: A) -> StaticMergedAppenderImpl<T, A, Self>
         where Self: Sized {
-        assert_eq!(self.max_dl(), appender.max_dl());
-        assert_eq!(self.max_rl(), appender.max_rl());
         StaticMergedAppenderImpl { appender, next: self, _dummy: PhantomData }
     }
     fn add_appender_map<A: ColumnAppender<T2>, T2: Clone, F: Fn(Cow<T>) -> Cow<T2>>(self, appender: A, f: F) -> StaticMergedAppenderImpl<T, PreprocessAppender<T, T2, A, F>, Self>

--- a/cli/src/datatypes/mod.rs
+++ b/cli/src/datatypes/mod.rs
@@ -3,3 +3,4 @@ pub mod money;
 pub mod jsonb;
 pub mod interval;
 pub mod array;
+pub mod pgvector;

--- a/cli/src/datatypes/pgvector.rs
+++ b/cli/src/datatypes/pgvector.rs
@@ -1,0 +1,106 @@
+use std::{borrow::Cow, iter::Map};
+
+use bit_vec::IntoIter;
+use byteorder::{ReadBytesExt, BigEndian, ByteOrder};
+use postgres::types::FromSql;
+use pgvector::{HalfVector, Vector, SparseVector};
+use half::f16;
+
+use crate::myfrom::MyFrom;
+
+#[derive(Debug, Clone)]
+pub struct PgF32Vector {
+	pub data: Vector
+}
+
+#[derive(Debug, Clone)]
+pub struct PgF16Vector {
+	pub data: HalfVector
+}
+
+#[derive(Debug, Clone)]
+pub struct PgSparseVector {
+	pub data: SparseVector
+}
+
+impl<'a> FromSql<'a> for PgF32Vector {
+	fn from_sql(ty: &postgres::types::Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(PgF32Vector { data: Vector::from_sql(ty, raw)? })
+	}
+
+	fn accepts(ty: &postgres::types::Type) -> bool {
+		Vector::accepts(ty)
+	}
+}
+
+impl<'a> FromSql<'a> for PgF16Vector {
+	fn from_sql(ty: &postgres::types::Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(PgF16Vector { data: HalfVector::from_sql(ty, raw)? })
+	}
+
+	fn accepts(ty: &postgres::types::Type) -> bool {
+		HalfVector::accepts(ty)
+	}
+}
+impl<'a> FromSql<'a> for PgSparseVector {
+	fn from_sql(ty: &postgres::types::Type, raw: &'a [u8]) -> Result<Self, Box<dyn std::error::Error + Sync + Send>> {
+        Ok(PgSparseVector { data: SparseVector::from_sql(ty, raw)? })
+	}
+
+	fn accepts(ty: &postgres::types::Type) -> bool {
+		ty.name() == "sparsevec"
+	}
+}
+
+impl<'a> IntoIterator for PgF32Vector {
+    type Item = f32;
+    type IntoIter = <Vec<f32> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.to_vec().into_iter() // TODO: remove copy
+    }
+}
+
+impl IntoIterator for PgF16Vector {
+    type Item = f16;
+    type IntoIter = <Vec<f16> as IntoIterator>::IntoIter;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.data.to_vec().into_iter()
+    }
+}
+
+impl IntoIterator for PgSparseVector {
+    type Item = (i32, f32);
+    type IntoIter = SparseVecIter<'static>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        if self.data.indices().len() > i32::MAX as usize {
+            panic!();
+        }
+
+        SparseVecIter {
+            vec: Cow::Owned(self.data),
+            index: 0
+        }
+    }
+}
+
+pub struct SparseVecIter<'a> {
+    vec: Cow<'a, SparseVector>,
+    index: i32
+}
+
+impl Iterator for SparseVecIter<'_> {
+    type Item = (i32, f32);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if (self.index as usize) < self.vec.indices().len() {
+            let result = (self.vec.indices()[self.index as usize], self.vec.values()[self.index as usize]);
+            self.index += 1;
+            Some(result)
+        } else {
+            None
+        }
+    }
+}

--- a/cli/src/main.rs
+++ b/cli/src/main.rs
@@ -4,7 +4,7 @@ use std::{sync::Arc, path::PathBuf, process};
 
 use clap::{Parser, ValueEnum, Command};
 use parquet::{basic::{ZstdLevel, BrotliLevel, GzipLevel, Compression}, file::properties::DEFAULT_WRITE_BATCH_SIZE};
-use postgres_cloner::{SchemaSettingsArrayHandling, SchemaSettingsEnumHandling, SchemaSettingsIntervalHandling, SchemaSettingsJsonHandling, SchemaSettingsMacaddrHandling, SchemaSettingsNumericHandling};
+use postgres_cloner::{SchemaSettingsArrayHandling, SchemaSettingsEnumHandling, SchemaSettingsFloat16Handling, SchemaSettingsIntervalHandling, SchemaSettingsJsonHandling, SchemaSettingsMacaddrHandling, SchemaSettingsNumericHandling};
 
 mod postgresutils;
 mod myfrom;
@@ -134,6 +134,9 @@ pub struct SchemaSettingsArgs {
     /// Parquet does not support multi-dimensional arrays and arrays with different starting index. pg2parquet flattens the arrays, and this options allows including the stripped information in additional columns.
     #[arg(long, hide_short_help = true, default_value = "plain")]
     array_handling: SchemaSettingsArrayHandling,
+    /// 
+    #[arg(long, hide_short_help = true, default_value = "float32")]
+    float16_handling: SchemaSettingsFloat16Handling,
 }
 
 
@@ -236,6 +239,7 @@ fn perform_export(args: ExportArgs) {
         decimal_scale: args.schema_settings.decimal_scale,
         decimal_precision: args.schema_settings.decimal_precision,
         array_handling: args.schema_settings.array_handling,
+        float16_handling: args.schema_settings.float16_handling,
     };
     let query = args.query.unwrap_or_else(|| {
         format!("SELECT * FROM {}", args.table.unwrap())

--- a/cli/src/parquetinfo.rs
+++ b/cli/src/parquetinfo.rs
@@ -7,21 +7,23 @@ use parquet::column::reader::ColumnReader;
 use parquet::schema::types::ColumnDescriptor;
 use std::fmt::{Display, Debug, Formatter};
 
+// Internal debugging tool: prints metadata and content of parquet file in text-form
+
 fn print_col_info<T: DataType<T = T2>, T2: Default + Clone + ParquetTypeFormat>(col_name: &str, col: &ColumnDescriptor, reader: &mut ColumnReaderImpl<T>) {
 	let batch_size = 300;
-	let mut data: Vec<T2> = vec![<T as DataType>::T::default(); batch_size];
-	let mut dls = vec![0; batch_size];
-	let mut rls = vec![0; batch_size];
+	let mut data: Vec<T2> = vec![];
+	let mut dls = vec![];
+	let mut rls = vec![];
 	let (record_count, valuecount, totalcount) = reader.read_records(batch_size, Some(&mut dls), Some(&mut rls), &mut data).unwrap();
 
-	let data_display = DisplayDataRow { vec: data[0..valuecount].to_vec(), lt: col.logical_type(), ct: col.converted_type() };
-	println!("{}: {:?} {}", col_name, (record_count, valuecount, totalcount), data_display);
+	let data_display = DisplayDataRow { vec: data, lt: col.logical_type(), ct: col.converted_type() };
+	println!("record_count={record_count} valuecount={valuecount} totalcount={totalcount} values={data_display}");
 
 	if dls.iter().any(|x| *x != 0) {
-		println!("dls: {:?}", dls[0..totalcount].to_vec());
+		println!("dls: {:?}", dls.to_vec());
 	}
 	if rls.iter().any(|x| *x != 0) {
-		println!("rls: {:?}", rls[0..totalcount].to_vec());
+		println!("rls: {:?}", rls.to_vec());
 	}
 }
 
@@ -32,10 +34,16 @@ pub fn print_parquet_info(_path: &std::path::PathBuf) {
 
 #[cfg(debug_assertions)]
 pub fn print_parquet_info(path: &std::path::PathBuf) {
+    use std::io::stdout;
+
+    use parquet::schema::types::to_thrift;
+
 	let file = std::fs::File::open(path).unwrap();
 	let reader = SerializedFileReader::new(file).unwrap();
 	let meta = reader.metadata();
 	let schema = meta.file_metadata().schema_descr();
+	print!("Metadata: ");
+	parquet::schema::printer::print_parquet_metadata(&mut stdout(), meta);
 
 	for row_group_i in 0..reader.num_row_groups() {
 		let rg = reader.get_row_group(row_group_i).unwrap();
@@ -45,7 +53,7 @@ pub fn print_parquet_info(path: &std::path::PathBuf) {
 			let column_meta = rg.metadata().columns()[column_i].clone();
 			let column_type = schema.column(column_i);
 			let name = column_meta.column_path().string();
-			println!("column: {} {:?}", name, column_meta);
+			println!("column: {} max_dl={} max_rl={}", name, column_meta.column_descr().max_def_level(), column_meta.column_descr().max_rep_level());
 
 			match column {
 				ColumnReader::BoolColumnReader(mut c) => print_col_info(&name, &column_type, &mut c),

--- a/cli/src/postgres_cloner.rs
+++ b/cli/src/postgres_cloner.rs
@@ -590,7 +590,7 @@ fn map_simple_type<TRow: PgAbstractRow + Clone + 'static>(
 		"vector" => resolve_vector_conv::<pgvector::PgF32Vector, f32, FloatType, _, TRow>(name, c, None, None, None, |v| v),
 		"halfvec" => match s.float16_handling {
 			SchemaSettingsFloat16Handling::Float16 =>
-				resolve_vector_conv::<pgvector::PgF16Vector, f16, FixedLenByteArrayType, _, TRow>(name, c, None, None, None, |v|
+				resolve_vector_conv::<pgvector::PgF16Vector, f16, FixedLenByteArrayType, _, TRow>(name, c, Some(2), None, None, |v|
 					FixedLenByteArray::from(ByteArray::from(v.to_be_bytes().to_vec()))),
 			SchemaSettingsFloat16Handling::Float32 =>
 				resolve_vector_conv::<pgvector::PgF16Vector, f16, FloatType, _, TRow>(name, c, None, None, None, |v| v.into())

--- a/cli/src/postgres_cloner.rs
+++ b/cli/src/postgres_cloner.rs
@@ -597,14 +597,15 @@ fn map_simple_type<TRow: PgAbstractRow + Clone + 'static>(
 		},
 		"sparsevec" => {
 			let inner_appender = new_static_merged_appender::<(i32, f32)>(c.definition_level + 2, c.repetition_level + 1)
-				.add_appender(GenericColumnAppender::<_, Int32Type, _>::new(c.definition_level + 2, c.repetition_level + 1, |v: (i32, f32)| v.0))
+				// index+1, because pgvector uses 0-based in binary, but 1-based in text and operators 
+				.add_appender(GenericColumnAppender::<_, Int32Type, _>::new(c.definition_level + 2, c.repetition_level + 1, |v: (i32, f32)| v.0 + 1))
 				.add_appender(GenericColumnAppender::<_, FloatType, _>::new(c.definition_level + 2, c.repetition_level + 1, |v: (i32, f32)| v.1));
 
 			let schema = ParquetType::group_type_builder(name)
 				.with_repetition(Repetition::OPTIONAL)
 				.with_fields(vec![
 					Arc::new(ParquetType::group_type_builder("key_value").with_repetition(Repetition::REPEATED).with_fields(vec![
-						Arc::new(ParquetType::primitive_type_builder("index", basic::Type::INT32)
+						Arc::new(ParquetType::primitive_type_builder("key", basic::Type::INT32)
 							.with_repetition(Repetition::REQUIRED)
 							.with_logical_type(Some(LogicalType::Integer { bit_width: 32, is_signed: false }))
 							.build().unwrap()),

--- a/py-tests/test_pgvector.py
+++ b/py-tests/test_pgvector.py
@@ -1,0 +1,174 @@
+import datetime
+from decimal import Decimal
+import math
+import uuid
+import wrappers
+import unittest
+import duckdb
+import json
+import polars as pl
+import pandas as pd
+import numpy as np
+
+
+class TestBasic(unittest.TestCase):
+    def test_basic_vectors(self):
+        file = wrappers.create_and_export(
+            "vector_simple", "id",
+            "id int, a vector(5), b halfvec(5), c sparsevec(5), d bit(5)",
+            """(1, '[1.0001,2,3,4,100000]', '[6.0e-8,9.0e-8,3,4,5]', '{1:-1,5:5.25}/5', '10001'),
+               (2, NULL, NULL, NULL, NULL)
+            """
+        )
+        duckdb_table = duckdb.read_parquet(file).fetchall()
+        pandas_df = pd.read_parquet(file, engine="pyarrow")
+        polars_df = pl.read_parquet(file)
+
+        self.assertEqual(duckdb_table[0][0], 1)
+        self.assertEqual(duckdb_table[0][1], [1.000100016593933, 2.0, 3.0, 4.0, 100000.0])
+        self.assertEqual(duckdb_table[0][2], [5.960464477539063e-08, 1.1920928955078125e-07, 3.0, 4.0, 5.0])
+        self.assertEqual(duckdb_table[0][3], {1:-1.0,5:5.25})
+        self.assertEqual(duckdb_table[0][4], '10001')
+        self.assertEqual(duckdb_table[1], (2, None, None, None, None))
+
+        self.assertEqual(polars_df.schema, {
+            "id": pl.Int32,
+            "a": pl.List(pl.Float32),
+            "b": pl.List(pl.Float32),
+            "c": pl.List(pl.Struct({"key": pl.UInt32, "value": pl.Float32})),
+            "d": pl.String
+        })
+        self.assertEqual(polars_df["id"].to_list(), [1, 2])
+        self.assertEqual(polars_df["a"].to_list(), [[1.000100016593933,2.0, 3.0, 4.0, 100000.0], None])
+        self.assertEqual(polars_df["b"].to_list(), [[5.960464477539063e-08, 1.1920928955078125e-07, 3.0, 4.0, 5.0], None])
+        self.assertEqual(polars_df["c"].to_list(), [[{'key': 1, 'value': -1.0}, {'key': 5, 'value': 5.25}], None])
+        self.assertEqual(polars_df["d"].to_list(), [ '10001', None ])
+
+
+    def test_vector_arrays(self):
+        file = wrappers.create_and_export(
+            "vector_arrays", "id",
+            "id int, a vector(2)[], b halfvec(2)[], c sparsevec(10)[], d bit(5)[]",
+            """(1, array['[1,2]'::vector], array['[1,2]'::halfvec], array['{4:1,8:2}/10'::sparsevec], array['10001'::bit(5)]),
+               (2, NULL, NULL, NULL, NULL),
+               (3, '{}'::vector[], '{}'::halfvec[], '{}'::sparsevec[], '{}'::bit[]),
+               (4, '{NULL}'::vector[], '{NULL}'::halfvec[], '{NULL}'::sparsevec[], '{NULL}'::bit[]),
+               (5, '{NULL,NULL}'::vector[], '{NULL,NULL}'::halfvec[], '{NULL,NULL}'::sparsevec[], '{NULL,NULL}'::bit[]),
+               (6, array['[0,0]'::vector], array['[0,0]'::halfvec], array['{}/10'::sparsevec,'{}/10'::sparsevec,'{}/10'::sparsevec], array['00000'::bit(5)]),
+               (7, array[NULL,'[1,2]'::vector,'[1,2]'::vector,'[1,2]'::vector,NULL,'[1,2]'::vector,NULL], array['[1,2]'::halfvec,NULL,'[1,2]'::halfvec,NULL], array[NULL,'{4:1,8:2}/10'::sparsevec,NULL,'{4:1,8:2}/10'::sparsevec,NULL], NULL)
+            """
+        )
+        duckdb_table = duckdb.read_parquet(file).fetchall()
+        polars_df = pl.read_parquet(file)
+        pandas_df = pd.read_parquet(file, engine="pyarrow")
+
+        self.assertEqual(polars_df.schema, {
+            "id": pl.Int32,
+            "a": pl.List(pl.List(pl.Float32)),
+            "b": pl.List(pl.List(pl.Float32)),
+            "c": pl.List(pl.List(pl.Struct({"key": pl.UInt32, "value": pl.Float32}))),
+            "d": pl.List(pl.String)
+        })
+
+        self.assertEqual(duckdb_table[0], (1, [[1.0,2.0]], [[1.0,2.0]], [{4:1.0,8:2.0}], ['10001']))
+        self.assertEqual(duckdb_table[1], (2, None, None, None, None))
+        self.assertEqual(duckdb_table[2], (3, [], [], [], []))
+        self.assertEqual(duckdb_table[3], (4, [None], [None], [None], [None]))
+        self.assertEqual(duckdb_table[4], (5, [None,None], [None,None], [None,None], [None,None]))
+        self.assertEqual(duckdb_table[5], (6, [[0.0,0.0]], [[0.0,0.0]], [{}, {}, {}], ['00000']))
+        self.assertEqual(duckdb_table[6], (7, [None,[1.0,2.0],[1.0,2.0],[1.0,2.0],None,[1.0,2.0],None], [[1.0,2.0],None,[1.0,2.0],None], [None,{4:1.0,8:2.0},None,{4:1.0,8:2.0},None], None))
+
+        polars_rows = list(polars_df.iter_rows())
+        self.assertEqual(polars_rows[0], (1, [[1.0,2.0]], [[1.0,2.0]], [[{"key":4, "value": 1.0}, {"key":8, "value": 2.0}]], ['10001']))
+        self.assertEqual(polars_rows[1], (2, None, None, None, None))
+        self.assertEqual(polars_rows[2], (3, [], [], [], []))
+        self.assertEqual(polars_rows[3], (4, [None], [None], [None], [None]))
+        self.assertEqual(polars_rows[4], (5, [None,None], [None,None], [None,None], [None,None]))
+        self.assertEqual(polars_rows[5], (6, [[0.0,0.0]], [[0.0,0.0]], [[], [], []], ['00000']))
+        self.assertEqual(polars_rows[6], (7, [None,[1.0,2.0],[1.0,2.0],[1.0,2.0],None,[1.0,2.0],None], [[1.0,2.0],None,[1.0,2.0],None], [None,[{"key":4, "value": 1.0}, {"key":8, "value": 2.0}],None,[{"key":4, "value": 1.0}, {"key":8, "value": 2.0}],None], None))
+
+        pandas_obj = json.loads(pandas_df.to_json(orient='records'))
+        self.assertEqual(pandas_obj[0], {"id": 1, "a": [[1.0,2.0]], "b": [[1.0,2.0]], "c": [[[4, 1.0], [8, 2.0]]], "d": ['10001']})
+        self.assertEqual(pandas_obj[1], {"id": 2, "a": None, "b": None, "c": None, "d": None})
+        self.assertEqual(pandas_obj[2], {"id": 3, "a": [], "b": [], "c": [], "d": []})
+        self.assertEqual(pandas_obj[3], {"id": 4, "a": [None], "b": [None], "c": [None], "d": [None]})
+        self.assertEqual(pandas_obj[4], {"id": 5, "a": [None,None], "b": [None,None], "c": [None,None], "d": [None,None]})
+        self.assertEqual(pandas_obj[5], {"id": 6, "a": [[0.0,0.0]], "b": [[0.0,0.0]], "c": [[], [], []], "d": ['00000']})
+        self.assertEqual(pandas_obj[6], {"id": 7, "a": [None,[1.0,2.0],[1.0,2.0],[1.0,2.0],None,[1.0,2.0],None], "b": [[1.0,2.0],None,[1.0,2.0],None], "c": [None,[[4, 1.0], [8, 2.0]],None,[[4, 1.0], [8, 2.0]],None], "d": None})
+
+
+    def test_float16_vectors(self):
+        file = wrappers.create_and_export(
+            "vector_float16", "id",
+            "id int, a halfvec(7), b halfvec(2)[]",
+            """(1, '[1.0001,0,1.001,-4,10000,10001,-10000]', array['[1,2]'::halfvec, '[3,4]'::halfvec,'[6.0e-8,9.0e-8]'::halfvec]),
+               (2, NULL, NULL),
+               (3, NULL, array[NULL,'[1,2]'::halfvec,NULL,NULL,NULL,'[1,2]'::halfvec,NULL])
+            """,
+            ["--float16-handling=float32"]
+        )
+        duckdb_table = duckdb.read_parquet(file).fetchall()
+        self.assertEqual(duckdb_table[0], (1, [1.0,0.0,1.0009765625,-4.0,10000.0,10000.0,-10000.0], [[1.0,2.0],[3.0,4.0],[5.960464477539063e-8, 1.1920928955078125e-7]]))
+        self.assertEqual(duckdb_table[1], (2, None, None))
+        self.assertEqual(duckdb_table[2], (3, None, [None, [1.0, 2.0], None, None, None, [1.0, 2.0], None]))
+
+        f16_file = wrappers.run_export_table("vector_float16_f16", "vector_float16", "id", ["--float16-handling=float16"])
+
+        f16_table = pd.read_parquet(f16_file, engine="pyarrow") # pandas/pyarrow is the only library which currently supports it
+        print(f16_file)
+        print(f16_table)
+        self.assertEqual(json.loads(f16_table["a"].to_json()), {"0": [1.0,0.0,1.0009765625,-4.0,10000.0,10000.0,-10000.0], "1": None,"2": None })
+        self.assertEqual(json.loads(f16_table["b"].to_json()), {
+            "0": [[1.0,2.0], [3.0,4.0],[5.96e-8, 1.192e-7]], # pandas is just losing precision in to_json (if only they had to_python...)
+            "1": None,
+            "2": [ None, [1.0,2.0], None, None, None, [1.0,2.0], None ]
+        })
+
+
+    def test_nested_composites(self):
+        wrappers.run_sql(
+            """CREATE TYPE cc_vector_wrapper AS (single vector, half halfvec);""",
+            """CREATE TYPE cc_vector_array AS (wrappers cc_vector_wrapper[], halfarr halfvec, sparse sparsevec);""",
+            """CREATE TYPE cc_vector_lvl3 AS (arr cc_vector_array[], notarray cc_vector_wrapper);""",
+        )
+
+        file = wrappers.create_and_export(
+            "vector_nested_composites", "id",
+            "id int, a cc_vector_wrapper[], b cc_vector_array, c cc_vector_array[], d cc_vector_lvl3[]",
+            """(1, NULL, NULL, NULL, NULL),
+               (2, '{}', row('{}'::cc_vector_wrapper[], NULL::halfvec, NULL::sparsevec), '{}', '{}'),
+               (3, array[NULL,row('[1,2]', '[5,6]')::cc_vector_wrapper,NULL,row('[1,2]', '[5,6]')::cc_vector_wrapper,NULL], NULL,NULL,NULL),
+
+               (4, NULL, row(array[row('[1,2]', '[5,6]')::cc_vector_wrapper,NULL,row('[1,2,3,4,5,6,7,8]', NULL)::cc_vector_wrapper], '[1,2]'::halfvec, '{4:1,8:2}/10'::sparsevec), NULL, NULL),
+
+               (5, NULL, NULL, array[row(array[row('[1,2]', '[5,6]')::cc_vector_wrapper,NULL::cc_vector_wrapper,row('[1,2,3,4,5,6,7,8]', NULL)::cc_vector_wrapper], '[1,2]'::halfvec, '{4:1,8:2}/10'::sparsevec)::cc_vector_array, row(NULL,NULL,NULL)::cc_vector_array, row('{}'::cc_vector_wrapper[],NULL,NULL)::cc_vector_array], NULL),
+
+               (6, NULL, NULL, NULL, array[
+                  row(
+                    array[
+                        NULL::cc_vector_array,
+                        row(array[row('[1,2]', '[5,6]')::cc_vector_wrapper,NULL,row('[1,2,3,4,5,6,7,8]', NULL)::cc_vector_wrapper], '[1,2]'::halfvec, '{4:1,8:2}/10'::sparsevec)::cc_vector_array,
+                        NULL::cc_vector_array
+                    ],
+                    row(NULL, '[1,2]')::cc_vector_wrapper
+                  )::cc_vector_lvl3,
+                  row('{}'::cc_vector_array[], row(NULL, NULL)::cc_vector_wrapper)::cc_vector_lvl3,
+                  row(NULL, NULL)::cc_vector_lvl3,
+                  NULL
+               ])
+            """
+        )
+
+        duckdb_table = duckdb.read_parquet(file).fetchall()
+        polars_df = pl.read_parquet(file)
+        pandas_df = pd.read_parquet(file, engine="pyarrow")
+
+        for x in duckdb_table: print(x)
+
+        self.assertEqual(duckdb_table[0], (1, None, None, None, None))
+        self.assertEqual(duckdb_table[1], (2, [], {'halfarr': None, 'sparse': None, 'wrappers': []}, [], []))
+        self.assertEqual(duckdb_table[2], (3, [None, {'single': [1.0, 2.0], 'half': [5.0, 6.0]}, None, {'single': [1.0, 2.0], 'half': [5.0, 6.0]}, None], None, None, None))
+        self.assertEqual(duckdb_table[3], (4, None, {'wrappers': [{'single': [1.0, 2.0], 'half': [5.0, 6.0]}, None, {'single': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], 'half': None}], 'halfarr': [1.0, 2.0], 'sparse': {4: 1.0, 8: 2.0}}, None, None))
+        self.assertEqual(duckdb_table[4], (5, None, None, [{'wrappers': [{'single': [1.0, 2.0], 'half': [5.0, 6.0]}, None, {'single': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], 'half': None}], 'halfarr': [1.0, 2.0], 'sparse': {4: 1.0, 8: 2.0}}, {'wrappers': None, 'halfarr': None, 'sparse': None}, {'wrappers': [], 'halfarr': None, 'sparse': None}], None))
+        self.assertEqual(duckdb_table[5], (6, None, None, None, [{'arr': [None, {'wrappers': [{'single': [1.0, 2.0], 'half': [5.0, 6.0]}, None, {'single': [1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0], 'half': None}], 'halfarr': [1.0, 2.0], 'sparse': {4: 1.0, 8: 2.0}}, None], 'notarray': {'single': None, 'half': [1.0, 2.0]}}, {'arr': [], 'notarray': {'single': None, 'half': None}}, {'arr': None, 'notarray': None}, None]))
+

--- a/py-tests/wrappers.py
+++ b/py-tests/wrappers.py
@@ -82,6 +82,7 @@ def run_sql(*commands: Union[str, sql.SQL, sql.Composed]):
 def run_pg2parquet(args: list[str]):
     r = subprocess.run([ pg2parquet_binary, *args ], env={
         "PGPASSWORD": pg2parquet_password,
+        "RUST_BACKTRACE": "1"
     }, capture_output=True)
     if r.returncode != 0:
         print(f"pg2parquet exited with code {r.returncode}. Stdout:")


### PR DESCRIPTION
* `vector` is serialized as float32 List (with required elements)
* `halfvector` is also serialized either as float32 List, or the new Parquet float16 if enabled with an option
* `sparsevec` is serialized as uint32 -> float32 Map (maybe we should add an option to make it a dense vector?)
* `bit` is already supported (they just add indexes to a built-in postgres type)

Resolves #28 